### PR TITLE
Fix #12 Create Player Jump

### DIFF
--- a/Brackeys Game Jam 2020.1/Assets/Scripts/PlayerScript.cs
+++ b/Brackeys Game Jam 2020.1/Assets/Scripts/PlayerScript.cs
@@ -6,7 +6,11 @@ public class PlayerScript : MonoBehaviour
 {
     private Rigidbody2D rb;
     [SerializeField]
-    private float playerSpeed = 5;
+    private float playerSpeed = 5.0f;
+    [SerializeField]
+    private float jumpForce = 5.0f;
+    [SerializeField]
+    private bool resetJump = false;
     void Start()
     {
         rb = GetComponent<Rigidbody2D>();
@@ -20,6 +24,32 @@ public class PlayerScript : MonoBehaviour
     private void Movement()
     {
         float horizontalInput = Input.GetAxisRaw("Horizontal");
+        
+        if (Input.GetKeyDown(KeyCode.Space) && IsGrounded() == true)
+        {
+            rb.velocity = new Vector2(rb.velocity.x, jumpForce);
+            StartCoroutine(ResetJumpRoutine());
+        }
+        
         rb.velocity = new Vector2(horizontalInput * playerSpeed, rb.velocity.y);
+    }
+
+    private bool IsGrounded()
+    {
+        //The Raycast Distance probabily will need to change when we change the player sprite. 
+        RaycastHit2D hitInfo = Physics2D.Raycast(transform.position, Vector2.down, 1.3f, 1 << 8);
+        //Debug.DrawRay(transform.position, Vector2.down * 1.3f, Color.green); Will be needed to test with the real player character
+        if (hitInfo.collider != null)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    IEnumerator ResetJumpRoutine()
+    {
+        resetJump = true;
+        yield return new WaitForSeconds(0.1f);
+        resetJump = false;
     }
 }


### PR DESCRIPTION
Player Jump mechanic created, it uses raycast to test if player is grounded, so it needed to be fixed when the main character player sprite is added to the game.